### PR TITLE
Add format parameter (to support TIFF/JPG files)

### DIFF
--- a/dash_canvas/utils/io_utils.py
+++ b/dash_canvas/utils/io_utils.py
@@ -2,8 +2,13 @@ from PIL import Image
 from io import BytesIO
 import base64
 
+_allowed_formats = {
+    "jpg",
+    "png",
+    "tiff",
+}
 
-def array_to_data_url(img, dtype=None):
+def array_to_data_url(img, dtype=None, format="png"):
     """
     Converts numpy array to data string, using Pillow.
 
@@ -14,6 +19,8 @@ def array_to_data_url(img, dtype=None):
     ==========
 
     img : numpy array
+    dtype : numpy datatype
+    format : Optional str, one of "jpg", "png" (default), or "tiff"
 
     Returns
     =======
@@ -22,11 +29,13 @@ def array_to_data_url(img, dtype=None):
     """
     if dtype is not None:
         img = img.astype(dtype)
+    if not format in _allowed_formats:
+        format = "png"
     pil_img = Image.fromarray(img)
     buff = BytesIO()
-    pil_img.save(buff, format="png")
-    prefix = b'data:image/png;base64,'
-    image_string = (prefix + base64.b64encode(buff.getvalue())).decode("utf-8")
+    pil_img.save(buff, format=format)
+    prefix = 'data:image/' + format + ';base64,'
+    image_string = prefix + base64.b64encode(buff.getvalue()).decode("utf-8")
     return image_string
 
 


### PR DESCRIPTION
For smaller images (e.g. 256x256 x3 RGB planes), saving as TIFF is faster by about an order of magnitude.